### PR TITLE
Fixed 'Units' value always being 'unit' in export

### DIFF
--- a/connect/cli/plugins/product/export.py
+++ b/connect/cli/plugins/product/export.py
@@ -344,7 +344,7 @@ def _fill_item_row(ws, row_idx, item):
     ws.cell(row_idx, 5, value=item['description'])
     ws.cell(row_idx, 6, value=item['type'])
     ws.cell(row_idx, 7, value=item['precision'])
-    ws.cell(row_idx, 8, value=item['unit']['id'])
+    ws.cell(row_idx, 8, value=item['unit']['title'])
     period = item.get('period', 'monthly')
     if period.startswith('years_'):
         period = f'{period.rsplit("_")[-1]} years'

--- a/connect/cli/plugins/product/export.py
+++ b/connect/cli/plugins/product/export.py
@@ -344,7 +344,7 @@ def _fill_item_row(ws, row_idx, item):
     ws.cell(row_idx, 5, value=item['description'])
     ws.cell(row_idx, 6, value=item['type'])
     ws.cell(row_idx, 7, value=item['precision'])
-    ws.cell(row_idx, 8, value=item['unit']['unit'])
+    ws.cell(row_idx, 8, value=item['unit']['id'])
     period = item.get('period', 'monthly')
     if period.startswith('years_'):
         period = f'{period.rsplit("_")[-1]} years'


### PR DESCRIPTION
In the current version of connect-cli when exporting product, the value
of column H on sheet 'Items' is always 'unit', no matter what is
configured on the portal.

This change changes the item processing logic to (what I assume to be)
the correct reference to unit of measure.