### PR TITLE
[HF] LITE-23615 Backport of Support for locales list, translations list, activate and primarize operations in Connect CLI

### DIFF
--- a/connect/cli/plugins/translation/commands.py
+++ b/connect/cli/plugins/translation/commands.py
@@ -16,6 +16,7 @@ from connect.cli.core.utils import (
 from connect.cli.plugins.translation.constants import TRANSLATION_TABLE_HEADER
 from connect.cli.plugins.translation.activate import activate_translation
 from connect.cli.plugins.translation.export import dump_translation
+from connect.cli.plugins.translation.primarize import primarize_translation
 from connect.client import ConnectClient, RequestLogger
 
 
@@ -181,6 +182,58 @@ def cmd_activate_translation(config, translation_id, force):
         click.secho(
             f'The translation {translation["id"]} on {translation["context"]["name"]} '
             'has been successfully activated.',
+            fg='green',
+        )
+
+
+@grp_translation.command(
+    name='primarize',
+    short_help='Primarize a translation.',
+)
+@click.argument('translation_id', metavar='TRANSLATION_ID', nargs=1, required=True)
+@click.option(
+    '--force',
+    '-f',
+    'force',
+    is_flag=True,
+    help='Force primarize.',
+)
+@pass_config
+def cmd_primarize_translation(config, translation_id, force):
+    acc_id = config.active.id
+    acc_name = config.active.name
+    if not config.silent:
+        click.secho(
+            f'Current active account: {acc_id} - {acc_name}\n',
+            fg='blue',
+        )
+        click.secho(
+            'Warning: You are about to make this translation primary.\n'
+            'This action can\'t be undone.\n'
+            'You will loose all of its attributes values, they will be '
+            'replaced with the original context attributes values.\n',
+            fg='yellow',
+        )
+        click.secho(
+            'Tip: You can clone this translation to keep a copy of the current values.\n',
+            fg='blue',
+        )
+    if not force:
+        click.confirm(
+            f'Are you sure you want to Primarize the translation {translation_id} ?',
+            abort=True,
+        )
+        click.echo()
+    translation = primarize_translation(
+        config.active.endpoint,
+        config.active.api_key,
+        translation_id,
+        config.verbose,
+    )
+    if not config.silent:
+        click.secho(
+            f'The translation {translation["id"]} on {translation["context"]["name"]} '
+            'has been successfully primarize.',
             fg='green',
         )
 

--- a/connect/cli/plugins/translation/primarize.py
+++ b/connect/cli/plugins/translation/primarize.py
@@ -1,0 +1,36 @@
+import click
+
+from connect.client import ClientError, ConnectClient, RequestLogger
+from connect.cli.core.http import (
+    format_http_status,
+    handle_http_error,
+)
+
+
+def primarize_translation(
+    api_url, api_key,
+    translation_id, verbose=False,
+):
+    try:
+        client = ConnectClient(
+            api_key=api_key,
+            endpoint=api_url,
+            use_specs=False,
+            max_retries=3,
+            logger=RequestLogger() if verbose else None,
+        )
+        payload = {
+            'primary': True,
+        }
+        translation = (
+            client.ns('localization')
+            .translations[translation_id]
+            .action('primarize')
+            .post(payload=payload)
+        )
+    except ClientError as error:
+        if error.status_code == 404:
+            status = format_http_status(error.status_code)
+            raise click.ClickException(f'{status}: Translation {translation_id} not found.')
+        handle_http_error(error)
+    return translation

--- a/docs/translations_usage.md
+++ b/docs/translations_usage.md
@@ -13,9 +13,10 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  activate  Active a translation.
-  export  Export a translation and its attributes to an excel file.
-  list    List translations.
+  activate   Active a translation.
+  export     Export a translation and its attributes to an excel file.
+  list       List translations.
+  primarize  Primarize a translation.
 ```
 
 ## List translation options
@@ -84,3 +85,28 @@ To export a translation and its attributes to Excel run:
 ```
 
 This command will generate a excel file named TRN-000-000-000.xlsx in the current working directory.
+
+
+## Primarize a translation
+
+To see the options for the primarize translation command run:
+
+```sh
+$ ccli translation primarize -h
+
+Usage: ccli translation primarize [OPTIONS] TRANSLATION_ID
+
+Options:
+  -f, --force  Force primarize.
+  -h, --help   Show this message and exit.
+
+```
+
+Then, to primarize a translation, run:
+
+```sh
+$ ccli translation primarize TRN-000-000-000
+```
+
+<b>When primarize a translation you will loose all of its attributes values, they will be replaced with the original context attributes values. This action can't be undone.</b> So as the same as `activate command`, you will receive a warning.
+You can also use the flag `-f, --force` to force the translation primarize.

--- a/tests/plugins/translation/test_commands.py
+++ b/tests/plugins/translation/test_commands.py
@@ -76,7 +76,7 @@ def test_list_translations(config_mocker, mocked_responses, mocked_translation_r
     assert result.exit_code == 0
     assert 'Current active account: VA-000 - Account 0' in result.output
     assert (
-        '│TRN-8100-3865-4869│PRD-746-555-769│  product   │translation test product│Spanish│off │active│       │     │' 
+        '│TRN-8100-3865-4869│PRD-746-555-769│  product   │translation test product│Spanish│off │active│       │     │'
         in result.output
     )
 
@@ -178,4 +178,105 @@ def test_force_activate_translation(config_mocker, mocker, mocked_translation_re
     assert (
         'The translation TRN-8100-3865-4869 on translation test '
         'product has been successfully activated.' in result.output
+    )
+
+
+def test_primarize_translation_command(config_mocker, mocker, mocked_translation_response, ccli):
+    mock = mocker.patch(
+        'connect.cli.plugins.translation.commands.primarize_translation',
+        side_effect=lambda *args: mocked_translation_response,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        ccli,
+        [
+            'translation',
+            'primarize',
+            'TRN-8100-3865-4869',
+        ],
+        input='y\n',
+    )
+
+    mock.assert_called_once()
+    assert mock.mock_calls[0][1][2] == 'TRN-8100-3865-4869'
+    assert mock.mock_calls[0][1][3] is False
+    assert result.exit_code == 0
+    assert 'Warning: You are about to make this translation primary.' in result.output
+    assert (
+        'The translation TRN-8100-3865-4869 on translation test '
+        'product has been successfully primarize.' in result.output
+    )
+
+
+def test_primarize_translation_silent(config_mocker, mocker, mocked_translation_response, ccli):
+    mock = mocker.patch(
+        'connect.cli.plugins.translation.commands.primarize_translation',
+        side_effect=lambda *args: mocked_translation_response,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        ccli,
+        [
+            '-s',
+            'translation',
+            'primarize',
+            'TRN-8100-3865-4869',
+        ],
+        input='y\n',
+    )
+
+    mock.assert_called_once()
+    assert mock.mock_calls[0][1][2] == 'TRN-8100-3865-4869'
+    assert mock.mock_calls[0][1][3] is False
+    assert result.exit_code == 0
+    assert 'Warning: You are about to make this translation primary.' not in result.output
+
+
+def test_abort_primarize_translation(config_mocker, mocker, mocked_translation_response, ccli):
+    mock = mocker.patch(
+        'connect.cli.plugins.translation.commands.primarize_translation',
+        side_effect=lambda *args: mocked_translation_response,
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        ccli,
+        [
+            'translation',
+            'primarize',
+            'TRN-8100-3865-4869',
+        ],
+        input='n\n',
+    )
+
+    mock.assert_not_called()
+    assert result.exit_code == 1
+    assert 'Aborted!' in result.output
+
+
+def test_force_primarize_translation(config_mocker, mocker, mocked_translation_response, ccli):
+    mock = mocker.patch(
+        'connect.cli.plugins.translation.commands.primarize_translation',
+        side_effect=lambda *args: mocked_translation_response,
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        ccli,
+        [
+            'translation',
+            'primarize',
+            '-f',
+            'TRN-8100-3865-4869',
+        ],
+    )
+
+    mock.assert_called_once()
+    assert mock.mock_calls[0][1][2] == 'TRN-8100-3865-4869'
+    assert mock.mock_calls[0][1][3] is False
+    assert result.exit_code == 0
+    assert 'Are you sure you want to Primarize the translation TRN-8100-3865-4869 ?' not in result.output
+    assert (
+        'The translation TRN-8100-3865-4869 on translation test '
+        'product has been successfully primarize.' in result.output
     )

--- a/tests/plugins/translation/test_primarize.py
+++ b/tests/plugins/translation/test_primarize.py
@@ -1,0 +1,63 @@
+import click
+import pytest
+
+from connect.cli.plugins.translation.primarize import primarize_translation
+
+
+def test_primarize_translation(
+    mocked_responses,
+    mocked_translation_response,
+):
+    mocked_translation_response['primary'] = True
+    mocked_responses.add(
+        method='POST',
+        url='https://localhost/public/v1/localization/translations/TRN-8100-3865-4869/primarize',
+        json=mocked_translation_response,
+        status=200,
+    )
+
+    translation = primarize_translation(
+        api_url='https://localhost/public/v1',
+        api_key='ApiKey XXX',
+        translation_id='TRN-8100-3865-4869',
+    )
+
+    assert translation['primary']
+
+
+def test_translation_already_primary(mocked_responses):
+    mocked_responses.add(
+        method='POST',
+        url='https://localhost/public/v1/localization/translations/TRN-8100-3865-4869/primarize',
+        json={
+            "error_code": "TRE_005",
+            "errors": [
+                "This translation is already a primary translation.",
+            ],
+        },
+        status=400,
+    )
+
+    with pytest.raises(click.ClickException) as e:
+        primarize_translation(
+            api_url='https://localhost/public/v1',
+            api_key='ApiKey XXX',
+            translation_id='TRN-8100-3865-4869',
+        )
+
+    assert str(e.value) == '400 - Bad Request: TRE_005 - This translation is already a primary translation.'
+
+
+def test_primarize_translation_not_exists(mocked_responses):
+    mocked_responses.add(
+        method='POST',
+        url='https://localhost/public/v1/localization/translations/TRN-0000-0000-0000/primarize',
+        status=404,
+    )
+    with pytest.raises(click.ClickException) as e:
+        primarize_translation(
+            api_url='https://localhost/public/v1',
+            api_key='ApiKey XXX',
+            translation_id='TRN-0000-0000-0000',
+        )
+    assert str(e.value) == '404 - Not Found: Translation TRN-0000-0000-0000 not found.'


### PR DESCRIPTION
This PR close the US [LITE-23304](https://jira.int.zone/browse/LITE-23304)

*Subtasks in this branch:
[[HF] LITE-23307 Add the command to primarize the translation](https://github.com/cloudblue/connect-cli/commit/96cfa5c3442a48eef9f502ee270e3165a3ad683b)

*Subtasks previously merged to `master` before `release/25` was created:
[LITE-23308 add command to list the locales #96](https://github.com/cloudblue/connect-cli/pull/96)
[LITE-23305 Add command for list of translations #98](https://github.com/cloudblue/connect-cli/pull/98)
[LITE-23306 Add command to activate a translation #99](https://github.com/cloudblue/connect-cli/pull/99)