### PR TITLE
LITE-23950: remove openpyxl warning about Data Validation

### DIFF
--- a/connect/cli/ccli.py
+++ b/connect/cli/ccli.py
@@ -10,6 +10,7 @@ from connect.cli.core.plugins import load_plugins
 
 
 def main():
+    _ignore_openpyxl_warnings()
     print('')
     try:
         load_plugins(cli)
@@ -25,6 +26,17 @@ def main():
         pass
     finally:
         print('')
+
+
+def _ignore_openpyxl_warnings():
+    """
+    Ignore warning about DataValidation extension not supported. This is shown when a xlsx file
+    with unsupported data validation is opened (tipically after saving the file from Excel, which
+    uses some custom extension).
+    To avoid losing data validation, it should be re-created each time the file is saved by the cli.
+    """
+    import warnings
+    warnings.filterwarnings('ignore', category=UserWarning, module='openpyxl.worksheet._reader')
 
 
 if __name__ == '__main__':

--- a/connect/cli/plugins/product/utils.py
+++ b/connect/cli/plugins/product/utils.py
@@ -152,9 +152,10 @@ def _calculate_translation_completion(translation):
 def setup_locale_data_validation(general_ws, translations_ws):
     """
     Setup DataValidation on locale column.
-    Some strange behavior makes it necessary to setup DataValidation every time the worksheet is
-    saved to ensure that it is not removed (probably because the locales list is in a formula
-    referencing a different sheet).
+    It is necessary to setup DataValidation every time the worksheet is saved to ensure that it is
+    not removed.
+    This is related to the openpyxl warning: DataValidation extension not supported and will be
+    removed.
     """
     row_idx = 2
     while general_ws[f'AB{row_idx + 1}'].value:


### PR DESCRIPTION
The warning `UserWarning: Data Validation extension is not supported and will be removed` is shown when a xlsx file with unsupported data validation is opened (typically after saving the file from Excel, which uses some custom extension). To avoid losing the data validation, it should be re-created each time the file is saved by the cli.
So instead of ignoring this warning globally, opted for a more conservative solution. The warning can be explicitly disabled by calling `load_workbook(..., no_warn=True)`, after it has been verified that the data validation is recreated correctly when the file is saved.

For now it is ignored in the known cases where it is handled correctly.