### PR TITLE
LITE-24436: pytest warnings fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ rich = "^12.4.1"
 poetry-core = "^1.0.8"
 
 [tool.poetry.dev-dependencies]
-
 pytest = "^6.1.2"
 pytest-cov = "^2.10.1"
 pytest-mock = "^3.3.1"
@@ -105,6 +104,12 @@ build-backend = "poetry.core.masonry.api"
 [tool.pytest.ini_options]
 testpaths = "tests"
 addopts = "-p no:cacheprovider --cov=connect.cli --cov-report=html --cov-report xml --cov-report term"
+filterwarnings = [
+    #flake8 get_style_guide deprecated API
+    "ignore:visit_Str is deprecated",
+    #openpyxl Data Validation extension is not supported and will be removed
+    "ignore::UserWarning",
+]
 
 [tool.coverage.run]
 branch = true

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,4 +1,3 @@
-import re
 import os.path
 from collections import OrderedDict
 
@@ -9,7 +8,6 @@ from requests import RequestException
 from connect.cli.core import utils
 from connect.cli.core.constants import PYPI_JSON_API_URL
 from connect.cli.core.utils import (
-    _ConnectVersionTag,
     sort_and_filter_tags,
 )
 
@@ -162,18 +160,6 @@ def test_field_to_check_mark_with_false_value():
     assert '-' == utils.field_to_check_mark(False, false_value='-')
 
 
-def test_row_format_resource():
-    fields = (
-        'ZH-HANS',
-        'Simplified Chinese',
-        '✓',
-        '-',
-    )
-    separators = len(fields) + 1
-    assert '| ZH-HANS | Simplified Chinese | ✓ | - |\n' == utils.row_format_resource(*fields)
-    assert separators == len(re.findall(r'\|', utils.row_format_resource(*fields)))
-
-
 @pytest.mark.parametrize(
     ('tags', 'expected'),
     (
@@ -234,49 +220,3 @@ def test_row_format_resource():
 def test_sort_and_filter_tags(tags, expected):
     sorted_tags = sort_and_filter_tags(tags, '21')
     assert sorted_tags == expected
-
-
-@pytest.mark.parametrize(
-    ('str', 'result'),
-    (
-        ('0.0.0', True),
-        ('0.0.4', True),
-        ('1.0.0', True),
-        ('1.2.0', True),
-        ('1.2.3', True),
-        ('0.0', True),
-        ('1.0', True),
-        ('10.20', True),
-        ('99999999999999999999999.999999999999999999.99999999999999999', True),
-        ('v0.0.4', True),
-        ('v1.2', True),
-        ('v01.23', True),
-        ('01.23', True),
-        ('01.23a1', True),
-        ('01.23b3', True),
-        ('01.23rc1', False),
-        ('1.1.2-prerelease+meta', False),
-        ('1.v2.0', False),
-        ('1.', False),
-        ('v1', False),
-    ),
-)
-def test_connect_version_tag(str, result):
-    assert (_ConnectVersionTag(str).plain_tag is None) == result
-
-
-@pytest.mark.parametrize(
-    'value',
-    (
-        '0.2.0',
-        'plain-tag-0.0.2a2',
-    ),
-)
-def test_connect_version_tag_eq_comparison(value):
-    first = _ConnectVersionTag(value)
-    assert first == value
-    assert first == _ConnectVersionTag(value)
-
-
-def test_connect_version_tag_invalid_comparison():
-    assert not _ConnectVersionTag(str) == 10


### PR DESCRIPTION
The idea is to remove all warnings that are displayed on the test result.

The usage of flake8 deprecated API was generating 672 Warnings.
tests/plugins/project/test_extension_helpers.py: 336 warnings
  /usr/local/Cellar/python@3.9/3.9.13_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ast.py:407: DeprecationWarning: visit_Str is deprecated; add visit_Constant
    return visitor(node)
 
So I considered the following solutions:
1 - Find a replacement to keep the same features. I did not find anything.
2 - Hide the warnings because everything is working fine (chosen)
3 - Delete the code that is generating the warnings. It is testing that the generated files of the extension bootstrap is compliant with some flake8 standards. Because we are generating those files It might not be much useful. The responsibility to have certain flake8 standards will be for the extension developer.

Also we had a warning because we are using unsupported data validations on the openpyxl library, but everything is working well:
tests/plugins/product/test_clone.py: 4 warnings
tests/plugins/product/test_commands.py: 2 warnings
tests/plugins/product/sync/test_general.py: 14 warnings
tests/plugins/shared/test_base.py: 5 warnings
tests/plugins/shared/test_translation_sync.py: 18 warnings
tests/plugins/shared/test_utils.py: 1 warning
  /Users/galonso00/.env/connect-cli/lib/python3.9/site-packages/openpyxl/worksheet/_reader.py:312: UserWarning: Data Validation extension is not supported and will be removed
    warn(msg)

I decided the hide the warnings also.