### PR TITLE
Clean up of project extension bootstrap

### DIFF
--- a/connect/cli/plugins/project/extension/helpers.py
+++ b/connect/cli/plugins/project/extension/helpers.py
@@ -91,7 +91,6 @@ def bootstrap_extension_project(config, output_dir, overwrite):  # noqa: CCR001
                 'static_root',
                 static_file,
             ) for static_file in [
-                'customer.html.j2',
                 'index.html.j2',
                 'page1.html.j2',
                 'settings.html.j2',
@@ -111,14 +110,13 @@ def bootstrap_extension_project(config, output_dir, overwrite):  # noqa: CCR001
                     f'{app_type}.py.j2',
                 ),
             )
-            if app_type == 'events':
-                exclude.append(
-                    os.path.join(
-                        answers['project_slug'],
-                        'tests',
-                        f'test_{answers["project_slug"]}.py.j2',
-                    ),
-                )
+            exclude.append(
+                os.path.join(
+                    answers['project_slug'],
+                    'tests',
+                    f'test_{app_type}.py.j2',
+                ),
+            )
 
     renderer = BoilerplateRenderer(
         context=ctx,

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/${package_name}/events.py.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/${package_name}/events.py.j2
@@ -45,7 +45,7 @@ from connect.eaas.core.responses import (
     },
 ])
 {% endif -%}
-class {{ project_slug|replace("_", " ")|title|replace(" ", "") }}Extension(BaseExtension):
+class {{ project_slug|replace("_", " ")|title|replace(" ", "") }}EventsExtension(BaseExtension):
     {% for bg_event in background -%}
     @event(
         '{{ bg_event }}',

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/${package_name}/extension.json.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/${package_name}/extension.json.j2
@@ -10,10 +10,6 @@
       "label": "Settings",
       "url": "/static/settings.html"
     },
-    "customer": {
-      "label": "Customer Portal UI",
-      "url": "/static/customer.html"
-    },
     "modules": {
       "label": "Main Page",
       "url": "/static/index.html",

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/${package_name}/static_root/customer.html.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/${package_name}/static_root/customer.html.j2
@@ -1,8 +1,0 @@
-<html>
-    <head>
-        <title>EaaS MA Customer Page</title>
-    </head>
-    <body>
-        <h1>This is an example</h1>
-    </body>
-</html>

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/${package_name}/webapp.py.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/${package_name}/webapp.py.j2
@@ -4,7 +4,6 @@
 # All rights reserved.
 #
 from fastapi import Depends, Request
-
 from connect.client import ConnectClient
 from connect.eaas.core.decorators import router, web_app
 from connect.eaas.core.extension import WebAppExtension
@@ -13,30 +12,23 @@ from connect.eaas.core.inject.synchronous import get_installation, get_installat
 
 @web_app(router)
 class {{ project_slug|replace("_", " ")|title|replace(" ", "") }}WebAppExtension(WebAppExtension):
+    installation: dict = Depends(get_installation)
+
     @router.get('/settings')
     def retrieve_settings(
         self,
-        installation: dict = Depends(get_installation),     # noqa: B008
     ):
-        return installation
+        return self.installation
 
     @router.post('/settings')
-    def update_settings(
+    async def update_settings(
         self,
         request: Request,
-        installation: dict = Depends(get_installation),     # noqa: B008
-        installation_client: ConnectClient = Depends(get_installation_client),     # noqa: B008
+        installation_client: ConnectClient = Depends(get_installation_client),
     ):
-        settings = request.json()
+        settings = await request.json()
 
-        installation_client('devops').installations[installation['id']].update(
+        installation_client('devops').installations[self.installation['id']].update(
             {'settings': settings},
         )
-        return installation_client('devops').installations[installation['id']].get()
-
-    @router.get('/whoami')
-    def whoami(
-        self,
-        installation_client: ConnectClient = Depends(get_installation_client),     # noqa: B008
-    ):
-        return installation_client.auth.action('context').get()
+        return installation_client('devops').installations[self.installation['id']].get()

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/.flake8.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/.flake8.j2
@@ -5,4 +5,4 @@ max-line-length = 100
 application-import-names = {{ package_name }}
 import-order-style = smarkets
 max-cognitive-complexity = 15
-ignore = FI1,I100,W503
+ignore = B008,FI1,I100,W503

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/HOWTO.md.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/HOWTO.md.j2
@@ -2,7 +2,7 @@
 
 ## Next steps
 
-You may open your favorite IDE and start working with your project, please note that this project runs using docker.
+You may open your favourite IDE and start working with your project, please note that this project runs using docker.
 You may modify at any time the credentials used to authenticate to connect modifying the file *{{ project_slug }}/.{{ project_slug }}_dev.env*.
 
 
@@ -28,6 +28,85 @@ Additionally, a basic boilerplate for writing unit tests has been created, you c
 $ docker compose up {{ project_slug }}_test
 ```
 
+## Types of extensions
+
+You can choose between two types of extension - regular (single tenant) extension or multi tenant one.
+Based on current active account you will be suggested a Fulfillment Automation or Hub Integration extension and MultiAccount one.
+
+## MultiAccount extensions
+
+If you have chosen MultiAccount type, then you to select what types of applications will be included in it. At least one application must be selected.
+
+### Events
+
+Events application is a regular extension in which you need to specify event handlers (described lower).
+
+### Web app
+
+Web application is a simple API based on FastAPI that can be provided with some interface.
+
+If you decided to use UI, you need to place all static files inside `static_root` directory.
+
+In `extension.json` you may specify icon to display in menu and settings for static files. Icon must be taken from [CloudBlue Connect material-svg library](https://github.com/cloudblue/material-svg), by default will be set puzzle icon.
+
+```json
+
+{
+  'icon': 'googleExtensionBaseline',
+  'ui': {
+    'settings': {
+      'label': 'Settings',
+      'url': '/static/settings.html'
+    },
+    'modules': {
+      'label': 'Main Page',
+      'url': '/static/index.html',
+      'children': [
+        {
+          'label': 'Page 1',
+          'url': '/static/page1.html'
+        }
+      ]
+    }
+  }
+}
+```
+
+To use Web application make sure, that Extension class is wrapped in `@web_app(router)` and define all desired endpoints based on `fastapi_utils` Class Based View approach.
+
+```python
+
+@web_app(router)
+class MyAwesomeProjectWebAppExtension(WebAppExtension):
+    @router.get('/settings')
+    def retrieve_settings(
+        self,
+        installation: dict = Depends(get_installation),
+    ):
+        return installation
+```
+
+### Anvil
+
+Here you may declare `@anvil_key_variable` - name of the variable containing API key for Anvil application.
+
+```python
+
+@anvil_key_variable('ANVIL_API_KEY')
+class MyAnvilExtension(AnvilExtension):
+    pass
+```
+
+And a set of `@anvil_callable` to interact with application.
+
+```python
+
+class MyAnvilExtension(AnvilExtension):
+
+    @anvil_callable()
+    def my_anvil_callable(self, arg1):
+        pass
+```
 
 ## Environment variables
 

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/pyproject.toml.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/pyproject.toml.j2
@@ -11,7 +11,7 @@ readme = "./README.md"
 
 [tool.poetry.plugins."connect.eaas.ext"]
 {%- if extension_type != 'multiaccount' or extension_type == 'multiaccount' and 'events' in application_types %}
-"extension" = "{{ package_name }}.events:{{ project_slug|replace("_", " ")|title|replace(" ", "") }}Extension"
+"extension" = "{{ package_name }}.events:{{ project_slug|replace("_", " ")|title|replace(" ", "") }}EventsExtension"
 {%- endif %}
 {%- if extension_type == 'multiaccount' and 'webapp' in application_types %}
 "webapp" = "{{ package_name }}.webapp:{{ project_slug|replace("_", " ")|title|replace(" ", "") }}WebAppExtension"
@@ -22,7 +22,8 @@ readme = "./README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
-connect-eaas-core = ">=3.4.0"
+connect-eaas-core = ">=3.8.0"
+fastapi = "^0.78.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/tests/conftest.py.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/tests/conftest.py.j2
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 from types import MethodType
 from urllib.parse import parse_qs
 
+from connect.client import {% if use_asyncio == 'y' %}AsyncConnectClient{% else %}ConnectClient{% endif %}
 {% if use_asyncio == 'y' -%}
 import httpx
 {% endif -%}
@@ -16,8 +17,6 @@ import pytest
 import requests
 {% endif -%}
 import responses
-
-from connect.client import {% if use_asyncio == 'y' %}AsyncConnectClient{% else %}ConnectClient{% endif %}
 
 
 ConnectResponse = namedtuple(
@@ -103,7 +102,6 @@ def _value_arg_validation(res):
 def response():
     with responses.RequestsMock() as rsps:
         yield rsps
-
 
 @pytest.fixture
 def logger(mocker):

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/tests/test_anvil.py.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/tests/test_anvil.py.j2
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2022, Globex Corporation
+# All rights reserved.
+#
+from {{ package_name }}.anvil import {{ project_slug|replace("_", " ")|title|replace(" ", "") }}AnvilExtension as AnvilExtension
+
+
+def test_get_anvil_key_variable():
+    assert AnvilExtension.get_anvil_key_variable() == 'ANVIL_API_KEY'
+
+    vars_dict = {v['name']: v for v in AnvilExtension.get_variables()}
+
+    assert vars_dict['ANVIL_API_KEY'] == {
+        'name': 'ANVIL_API_KEY',
+        'initial_value': 'changeme!',
+        'secure': True,
+    }
+
+    assert vars_dict['VAR_NAME_1'] == {
+        'name': 'VAR_NAME_1',
+        'initial_value': 'VAR_VALUE_1',
+        'secure': False,
+    }
+
+
+def test_setup_anvil_callables(mocker):
+
+    mocked_callable = mocker.patch(
+        'connect.eaas.core.extension.anvil.server.callable',
+    )
+
+    ext = AnvilExtension(None, None, None)
+
+    ext.setup_anvil_callables()
+
+    assert callable(mocked_callable.mock_calls[0].args[0])
+    assert mocked_callable.mock_calls[0].args[0].__name__ == 'hello'

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/tests/test_events.py.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/tests/test_events.py.j2
@@ -6,7 +6,7 @@
 {% if use_asyncio == 'y' -%}
 import pytest
 {% endif -%}
-from {{ package_name }}.events import {{ project_slug|replace("_", " ")|title|replace(" ", "") }}Extension
+from {{ package_name }}.events import {{ project_slug|replace("_", " ")|title|replace(" ", "") }}EventsExtension
 
 {% for bg_event in background -%}
 {% if use_asyncio == 'y' %}
@@ -24,7 +24,7 @@ from {{ package_name }}.events import {{ project_slug|replace("_", " ")|title|re
         response_factory(value=[{'id': 'item-1', 'value': 'value1'}]),
     ]
     client = {% if use_asyncio == 'y' %}await async_client_factory{% else %}sync_client_factory{% endif %}(responses)
-    ext = {{ project_slug|replace("_", " ")|title|replace(" ", "") }}Extension(client, logger, config)
+    ext = {{ project_slug|replace("_", " ")|title|replace(" ", "") }}EventsExtension(client, logger, config)
     result = {% if use_asyncio == 'y' %}await {% endif %}ext.handle_{{ bg_event }}(request)
     assert result.status == 'success'
 
@@ -46,7 +46,7 @@ from {{ package_name }}.events import {{ project_slug|replace("_", " ")|title|re
         response_factory(value=[{'id': 'item-1', 'value': 'value1'}]),
     ]
     client = {% if use_asyncio == 'y' %}await async_client_factory{% else %}sync_client_factory{% endif %}(responses)
-    ext = {{ project_slug|replace("_", " ")|title|replace(" ", "") }}Extension(client, logger, config)
+    ext = {{ project_slug|replace("_", " ")|title|replace(" ", "") }}EventsExtension(client, logger, config)
     result = {% if use_asyncio == 'y' %}await {% endif %}ext.handle_{{ interactive_event }}(request)
     assert result.status == 'success'
     assert result.body == request
@@ -69,7 +69,7 @@ from {{ package_name }}.events import {{ project_slug|replace("_", " ")|title|re
         response_factory(value=[{'id': 'item-1', 'value': 'value1'}]),
     ]
     client = {% if use_asyncio == 'y' %}await async_client_factory{% else %}sync_client_factory{% endif %}(responses)
-    ext = {{ project_slug|replace("_", " ")|title|replace(" ", "") }}Extension(client, logger, config)
+    ext = {{ project_slug|replace("_", " ")|title|replace(" ", "") }}EventsExtension(client, logger, config)
     result = {% if use_asyncio == 'y' %}await {% endif %}ext.execute_scheduled_processing(request)
     assert result.status == 'success'
 {% endif -%}

--- a/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/tests/test_webapp.py.j2
+++ b/connect/cli/plugins/project/extension/templates/bootstrap/${project_slug}/tests/test_webapp.py.j2
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) {% now 'utc', '%Y' %}, {{ author }}
+# All rights reserved.
+#
+import json
+
+from fastapi import Depends, Request
+
+from connect.client import ConnectClient
+from connect.eaas.core.testing import WebAppTestClient
+from connect.eaas.core.decorators import router, web_app
+from connect.eaas.core.extension import WebAppExtension
+from connect.eaas.core.inject.synchronous import get_installation, get_installation_client
+
+from {{ package_name }}.webapp import {{ project_slug|replace("_", " ")|title|replace(" ", "") }}WebAppExtension
+
+
+def test_get_settings(response, mocker):
+    mocker.patch(
+        'connect.eaas.core.extension.WebAppExtension.get_static_root',
+        return_value='./',
+    )
+    mocker.patch(
+        'connect.eaas.core.testing.FastAPI.mount',
+    )
+
+    response.add(
+        'GET',
+        'https://localhost/public/v1/devops/installations/installation_id',
+        json={'id': 'EIN-000-000'},
+        status=200,
+    )
+
+    client = WebAppTestClient(
+        {{ project_slug|replace("_", " ")|title|replace(" ", "") }}WebAppExtension,
+        default_headers={
+            'X-Connect-Api-Gateway-Url': 'https://localhost/public/v1',
+            'X-Connect-User-Agent': 'user-agent',
+        },
+    )
+
+    res = client.get(
+        '/settings',
+        headers={
+            'X-Connect-Installation-Api-Key': 'installation_api_key',
+            'X-Connect-Installation-Id': 'installation_id',
+        },
+    )
+    data = res.json()
+
+    assert res.status_code == 200
+    assert data == {'id': 'EIN-000-000'}
+
+
+def test_update_settings(response):
+    response.add(
+        'GET',
+        'https://localhost/public/v1/devops/installations/installation_id',
+        json={'id': 'EIN-000-000'},
+        status=200,
+    )
+    response.add(
+        'PUT',
+        'https://localhost/public/v1/devops/installations/EIN-000-000',
+        json={'id': 'EIN-000-000'},
+        status=200,
+    )
+    response.add(
+        'GET',
+        'https://localhost/public/v1/devops/installations/EIN-000-000',
+        json={'id': 'EIN-000-000', 'settings': {'attr': 'new_value'}},
+        status=200,
+    )
+
+    client = WebAppTestClient(
+        {{ project_slug|replace("_", " ")|title|replace(" ", "") }}WebAppExtension,
+        default_headers={
+            'X-Connect-Api-Gateway-Url': 'https://localhost/public/v1',
+            'X-Connect-User-Agent': 'user-agent',
+        },
+    )
+    res = client.post(
+        '/settings',
+        headers={
+            'X-Connect-Installation-Api-Key': 'installation_api_key',
+            'X-Connect-Installation-Id': 'installation_id',
+        },
+        data=json.dumps({'attr': 'new_value'}).encode('utf-8'),
+    )
+    data = res.json()
+
+    assert res.status_code == 200
+    assert data == {'id': 'EIN-000-000', 'settings': {'attr': 'new_value'}}
+
+    assert len(response.calls) == 3
+
+    payload = json.loads(response.calls[1].request.body)
+    assert payload == {'settings': {'attr': 'new_value'}}

--- a/tests/data.py
+++ b/tests/data.py
@@ -16,7 +16,7 @@ CONFIG_DATA = {
     ],
 }
 
-EXTENSION_CLASS_DECLARATION = 'class {extension_name}Extension(BaseExtension):'
+EXTENSION_CLASS_DECLARATION = 'class {extension_name}EventsExtension(BaseExtension):'
 EXTENSION_VARIABLES_DECLARATION = """@variables([
     {
         'name': 'VAR_NAME_1',
@@ -68,7 +68,7 @@ TEST_BG_EVENT = """{pytest_asyncio}{async_def}def test_handle_sample_background_
         response_factory(value=[{{'id': 'item-1', 'value': 'value1'}}]),
     ]
     client = {await_keyword}{client_factory_prefix}client_factory(responses)
-    ext = {extension_name}Extension(client, logger, config)
+    ext = {extension_name}EventsExtension(client, logger, config)
     result = {await_keyword}ext.handle_sample_background_event(request)
     assert result.status == 'success'"""
 
@@ -108,7 +108,7 @@ TEST_INTERACTIVE_EVENT = """{pytest_asyncio}{async_def}def test_handle_sample_in
         response_factory(value=[{{'id': 'item-1', 'value': 'value1'}}]),
     ]
     client = {await_keyword}{client_factory_prefix}client_factory(responses)
-    ext = {extension_name}Extension(client, logger, config)
+    ext = {extension_name}EventsExtension(client, logger, config)
     result = {await_keyword}ext.handle_sample_interactive_event(request)
     assert result.status == 'success'
     assert result.body == request"""
@@ -126,6 +126,6 @@ TEST_SCHEDULABLE_EVENT = """{pytest_asyncio}{async_def}def test_execute_schedule
         response_factory(value=[{{'id': 'item-1', 'value': 'value1'}}]),
     ]
     client = {await_keyword}{client_factory_prefix}client_factory(responses)
-    ext = {extension_name}Extension(client, logger, config)
+    ext = {extension_name}EventsExtension(client, logger, config)
     result = {await_keyword}ext.execute_scheduled_processing(request)
     assert result.status == 'success'"""

--- a/tests/plugins/project/test_extension_helpers.py
+++ b/tests/plugins/project/test_extension_helpers.py
@@ -113,7 +113,9 @@ def test_bootstrap_extension_project_background(
         pyproject_toml = toml.load(os.path.join(tmpdir, data['project_slug'], 'pyproject.toml'))
 
         ext_entrypoint = pyproject_toml['tool']['poetry']['plugins']['connect.eaas.ext']
-        assert ext_entrypoint == {'extension': f"{data['package_name']}.events:{classname_prefix}Extension"}
+        assert ext_entrypoint == {
+            'extension': f"{data['package_name']}.events:{classname_prefix}EventsExtension",
+        }
 
         if with_github_actions:
             assert os.path.exists(
@@ -137,7 +139,7 @@ def test_bootstrap_extension_project_background(
 
         report = flake8_style_guide.check_files([
             os.path.join(tmpdir, data['project_slug'], data['package_name'], 'events.py'),
-            os.path.join(tmpdir, data['project_slug'], 'tests', f'test_{data["project_slug"]}.py'),
+            os.path.join(tmpdir, data['project_slug'], 'tests', 'test_events.py'),
         ])
         assert report.total_errors == 0
 
@@ -159,7 +161,7 @@ def test_bootstrap_extension_project_background(
         assert extension_bg_event(async_impl=async_impl) in extension_py
 
         test_py = open(
-            os.path.join(tmpdir, data['project_slug'], 'tests', f'test_{data["project_slug"]}.py'),
+            os.path.join(tmpdir, data['project_slug'], 'tests', 'test_events.py'),
         ).read()
 
         assert test_bg_event(classname_prefix, async_impl=async_impl) in test_py
@@ -264,7 +266,9 @@ def test_bootstrap_extension_project_interactive(
         pyproject_toml = toml.load(os.path.join(tmpdir, data['project_slug'], 'pyproject.toml'))
 
         ext_entrypoint = pyproject_toml['tool']['poetry']['plugins']['connect.eaas.ext']
-        assert ext_entrypoint == {'extension': f"{data['package_name']}.events:{classname_prefix}Extension"}
+        assert ext_entrypoint == {
+            'extension': f"{data['package_name']}.events:{classname_prefix}EventsExtension",
+        }
 
         if with_github_actions:
             assert os.path.exists(
@@ -288,7 +292,7 @@ def test_bootstrap_extension_project_interactive(
 
         report = flake8_style_guide.check_files([
             os.path.join(tmpdir, data['project_slug'], data['package_name'], 'events.py'),
-            os.path.join(tmpdir, data['project_slug'], 'tests', f'test_{data["project_slug"]}.py'),
+            os.path.join(tmpdir, data['project_slug'], 'tests', 'test_events.py'),
         ])
         assert report.total_errors == 0
 
@@ -309,7 +313,7 @@ def test_bootstrap_extension_project_interactive(
         assert extension_interactive_event(async_impl=async_impl) in extension_py
 
         test_py = open(
-            os.path.join(tmpdir, data['project_slug'], 'tests', f'test_{data["project_slug"]}.py'),
+            os.path.join(tmpdir, data['project_slug'], 'tests', 'test_events.py'),
         ).read()
 
         assert test_interactive_event(classname_prefix, async_impl=async_impl) in test_py
@@ -405,7 +409,7 @@ def test_bootstrap_extension_project_multiaccount(
         ext_entrypoint = pyproject_toml['tool']['poetry']['plugins']['connect.eaas.ext']
         assert ext_entrypoint == {
             'anvil': f"{data['package_name']}.anvil:{classname_prefix}AnvilExtension",
-            'extension': f"{data['package_name']}.events:{classname_prefix}Extension",
+            'extension': f"{data['package_name']}.events:{classname_prefix}EventsExtension",
         }
 
         parser = configparser.ConfigParser()
@@ -425,7 +429,8 @@ def test_bootstrap_extension_project_multiaccount(
 
         report = flake8_style_guide.check_files([
             os.path.join(tmpdir, data['project_slug'], data['package_name'], 'events.py'),
-            os.path.join(tmpdir, data['project_slug'], 'tests', f'test_{data["project_slug"]}.py'),
+            os.path.join(tmpdir, data['project_slug'], 'tests', 'test_events.py'),
+            os.path.join(tmpdir, data['project_slug'], 'tests', 'test_anvil.py'),
         ])
         assert report.total_errors == 0
 
@@ -437,13 +442,13 @@ def test_bootstrap_extension_project_multiaccount(
         ).read()
 
         assert 'from connect.eaas.core.extension import EventsExtension' in events_py
-        assert f'class {classname_prefix}Extension(BaseExtension):' in events_py
+        assert f'class {classname_prefix}EventsExtension(BaseExtension):' in events_py
         assert f'class {classname_prefix}AnvilExtension(AnvilExtension):' in anvil_py
 
         assert extension_bg_event(async_impl=False) in events_py
 
         test_py = open(
-            os.path.join(tmpdir, data['project_slug'], 'tests', f'test_{data["project_slug"]}.py'),
+            os.path.join(tmpdir, data['project_slug'], 'tests', 'test_events.py'),
         ).read()
 
         assert test_bg_event(classname_prefix, async_impl=False) in test_py


### PR DESCRIPTION
- [x] Remove whoami endpoint from example
- [x] add tests for web application
- [x] add tests for anvil application
- [x] change events app extension class to include the "Events" suffix
- [x] improve the howto.md
- [x] split tests by app type
- [x] remove customer.html from generated project
- ~~improve html/is example (include or ui-toolkit)~~
- [x] Add B008 to ignored flake8 errors
- Validation of webapp decorators (main for class and routes) should be done not on source code but with inspection if possible --> not possible